### PR TITLE
Fix indent in docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,21 @@ docker run --rm -i -t -p 8766:8766/tcp -p 8766:8766/udp -p 27015:27015/tcp -p 27
 Docker-Compose:
 ```yaml
 version: "3.7"
-  services:
-    the-forest-dedicated-server:
-      container_name: the-forest-dedicated-server
-      image: jammsen/the-forest-dedicated-server:latest
-      restart: always
-      ports:
-        - 8766:8766/tcp
-        - 8766:8766/udp
-        - 27015:27015/tcp
-        - 27015:27015/udp
-        - 27016:27016/tcp
-        - 27016:27016/udp
-      volumes:
-        - /srv/tfds/steamcmd:/steamcmd
-        - /srv/tfds/game:/theforest
+services:
+  the-forest-dedicated-server:
+    container_name: the-forest-dedicated-server
+    image: jammsen/the-forest-dedicated-server:latest
+    restart: always
+    ports:
+      - 8766:8766/tcp
+      - 8766:8766/udp
+      - 27015:27015/tcp
+      - 27015:27015/udp
+      - 27016:27016/tcp
+      - 27016:27016/udp
+    volumes:
+      - /srv/tfds/steamcmd:/steamcmd
+      - /srv/tfds/game:/theforest
 ```
 
 ## Planned features in the future

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
 version: "3.7"
-  services:
-    the-forest-dedicated-server:
-      container_name: the-forest-dedicated-server
-      image: jammsen/the-forest-dedicated-server:latest
-      restart: always
-      ports:
-        - 8766:8766/tcp
-        - 8766:8766/udp
-        - 27015:27015/tcp
-        - 27015:27015/udp
-        - 27016:27016/tcp
-        - 27016:27016/udp
-      volumes:
-        - /srv/tfds/steamcmd:/steamcmd
-        - /srv/tfds/game:/theforest
+services:
+  the-forest-dedicated-server:
+    container_name: the-forest-dedicated-server
+    image: jammsen/the-forest-dedicated-server:latest
+    restart: always
+    ports:
+      - 8766:8766/tcp
+      - 8766:8766/udp
+      - 27015:27015/tcp
+      - 27015:27015/udp
+      - 27016:27016/tcp
+      - 27016:27016/udp
+    volumes:
+      - /srv/tfds/steamcmd:/steamcmd
+      - /srv/tfds/game:/theforest


### PR DESCRIPTION
The provided docker-compose example isn't indented correctly, due to the problem that "services" starts indented, which should not.