### PR TITLE
Issues regarding server recreation and template parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV WINEPREFIX=/winedata/WINE64 \
     PGID=0 \
     SERVER_STEAM_ACCOUNT_TOKEN=""
 
-VOLUME ["/theforest", "/steamcmd"]
+VOLUME ["/theforest", "/steamcmd", "/winedata"]
 
 EXPOSE 8766/tcp 8766/udp 27015/tcp 27015/udp 27016/tcp 27016/udp
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ services:
       - 27015:27015/udp
       - 27016:27016/tcp
       - 27016:27016/udp
-    volumes:
-      - /srv/tfds/steamcmd:/steamcmd
-      - /srv/tfds/game:/theforest
 ```
 
 ## Planned features in the future

--- a/server.cfg.example
+++ b/server.cfg.example
@@ -18,7 +18,7 @@ serverPassword
 // Server administration password. blank means no password
 serverPasswordAdmin
 // Your Steam account name. blank means anonymous
-serverSteamAccount ###serverSteamAccount###
+serverSteamAccount ##serverSteamAccount##
 // Time between server auto saves in minutes - The minumum time is 15 minutes, the default time is 30
 serverAutoSaveInterval 30
 // Game difficulty mode. Must be set to Peaceful Normal or Hard


### PR DESCRIPTION
## "Login Failure"
### Bug
When following documentation the server failed to authenticate against the Steam dedicated server with the error message: 
```
failed to connect to steam
```
### Cause
This is the line in question, this looks for double "#" wrapping the keyword:
```
sed -i -e "s/##serverSteamAccount##/$SERVER_STEAM_ACCOUNT_TOKEN/g" $CONFIGFILE_PATH
```
But the source has triple "#" as a result this leaves a leading and a trailing hashtag which creates an incorrect login token.
```
###serverSteamAccount###
```
### Resolution
 Remove the one leading and trailing hastags from the source.

## "Container Recreation Error"
### Bug
As noted in #25, when recreating the container the following error message is presented:
```
wine: chdir to /winedata/WINE64 : No such file or directory
```
### Cause
This is an edge case where the Dockerfile creates explicit volumes for `/theforest` and `/steamcmd` but when the container is recreated (as often happens in `docker-compose`) the directory dependency on `/winedata` is destroyed.
This is a problem because the entry file checks for the existence of `TheForestDedicatedServer.exe` from `/theforest` and therefore does not source and prepare Wine which is referenced in `/winedata`.
### Resolution
We could put a lot more logical checks in the entry script but instead if we persist `/winedata` it makes it easier when the container needs to recreate as it is a dependency as any other volume.