### PR TITLE
[Feature] Add the Update on start logic to the forest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV WINEPREFIX=/winedata/WINE64 \
     DEBIAN_FRONTEND=noninteractive \
     PUID=0 \
     PGID=0 \
-    SERVER_STEAM_ACCOUNT_TOKEN=""
+    SERVER_STEAM_ACCOUNT_TOKEN="" \
+    ALWAYS_UPDATE_ON_START=1
 
 VOLUME ["/theforest", "/steamcmd", "/winedata"]
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ services:
     restart: always
     environment:
       SERVER_STEAM_ACCOUNT_TOKEN: YOUR_TOKEN_HERE
+      ALWAYS_UPDATE_ON_START: 1
     ports:
       - 8766:8766/tcp
       - 8766:8766/udp

--- a/usr/bin/servermanager.sh
+++ b/usr/bin/servermanager.sh
@@ -66,6 +66,12 @@ function installServer() {
     bash /steamcmd/steamcmd.sh +runscript /steamcmdinstall.txt
 }
 
+function updateServer() {
+    # force an update and validation
+    echo ">>> Doing an update of the gameserver"
+    bash /steamcmd/steamcmd.sh +runscript /steamcmdinstall.txt
+}
+
 function startServer() {
     if ! isVirtualScreenRunning; then
         startVirtualScreenAndRebootWine
@@ -79,6 +85,9 @@ function startMain() {
     # Check if server is installed, if not try again
     if [ ! -f "/theforest/TheForestDedicatedServer.exe" ]; then
         installServer
+    fi
+    if [ $ALWAYS_UPDATE_ON_START == 1 ]; then
+        updateServer
     fi
     startServer
 }


### PR DESCRIPTION
This PR adds the logic jammsen added to the sons of the forest container for updating the game on start. If you pair this with a cronjob that restarts your containers during off times then you can keep your servers reasonably up to date. 